### PR TITLE
13-check-when-output-is-terminal-to-avoid-piping-errors

### DIFF
--- a/.quests.yaml
+++ b/.quests.yaml
@@ -333,7 +333,6 @@ quests:
     path: /post
     json: '{"debug": true}'
     verbose: true
-    include: true
     # Shows detailed request/response info with headers
 
   # Request with timeout and retry settings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quest-cli"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 description = "A cli for going on http fetch (re)quests. Requests can be templated and aliased for easier use."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quest-cli"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "A cli for going on http fetch (re)quests. Requests can be templated and aliased for easier use."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -315,12 +315,6 @@ quest get https://api.example.com/data -o response.json
 quest get https://api.example.com/data --output response.json
 ```
 
-**Include Response Headers:**
-```sh
-quest get https://api.example.com/data -i
-quest get https://api.example.com/data --include
-```
-
 **Request Compressed Response:**
 ```sh
 quest get https://api.example.com/data --compressed
@@ -461,7 +455,6 @@ quests:
 
 **Output:**
 - `output`: Output file path
-- `include`: Include response headers (boolean)
 - `compressed`: Request compressed response (boolean)
 - `simple`: Simple output without color (boolean)
 - `verbose`: Verbose output (boolean)

--- a/tests/cli_integration_test.rs
+++ b/tests/cli_integration_test.rs
@@ -414,19 +414,6 @@ fn test_output_to_file() {
 }
 
 #[test]
-fn test_include_headers_in_output() {
-    let mut cmd = quest_cmd();
-    cmd.arg("get")
-        .arg("https://httpbin.org/get")
-        .arg("--include");
-
-    cmd.assert()
-        .success()
-        .stdout(predicate::str::contains("HTTP/1.1"))
-        .stdout(predicate::str::contains("content-type:"));
-}
-
-#[test]
 fn test_env_file_loading() {
     let temp_dir = tempfile::tempdir().unwrap();
     let env_file = temp_dir.path().join(".env");


### PR DESCRIPTION
New output handler uses fail through approach for output printing/writing. json -> utf8 -> binary and will fail to write to stdout for binary.

- Fixes bug with broken pipes causing a panic due to using println. New code uses writeln and silences broken pipe.
- Additionally, adds handling to use plain text output when writing to a file.
- Now handles binary output.

